### PR TITLE
fix(protractor-$timeout): use $interval service for reply timeouts so pr...

### DIFF
--- a/src/service.coffee
+++ b/src/service.coffee
@@ -125,7 +125,7 @@ angular.module('knalli.angular-vertxbus')
     return this
   @skipUnauthorizeds.displayName = "#{CONSTANTS.MODULE}/#{CONSTANTS.COMPONENT}: provider.skipUnauthorizeds"
 
-  @$get = ($rootScope, $q, $interval, $timeout, vertxEventBus, $log) ->
+  @$get = ($rootScope, $q, $interval, vertxEventBus, $log) ->
     # Extract options (with defaults)
     { enabled, debugEnabled, prefix, urlServer, urlPath, reconnectEnabled,
       sockjsStateInterval, sockjsReconnectInterval, sockjsOptions,
@@ -219,7 +219,7 @@ angular.module('knalli.angular-vertxbus')
           vertxEventBus.send address, message, (reply) ->
             if deferred then deferred.resolve reply
           # Register timeout for promise rejecting.
-          if deferred then $timeout (-> deferred.reject()), timeout
+          if deferred then $interval (-> deferred.reject()), timeout, 1
         next.displayName = "#{CONSTANTS.MODULE}/#{CONSTANTS.COMPONENT}: util.send (ensureOpenAuthConnection callback)"
         dispatched = ensureOpenAuthConnection next
         if deferred and !dispatched then deferred.reject()
@@ -248,7 +248,7 @@ angular.module('knalli.angular-vertxbus')
             $rootScope.$broadcast "#{prefix}system.login.failed", (status: reply?.status)
         next.displayName = "#{CONSTANTS.MODULE}/#{CONSTANTS.COMPONENT}: util.login (callback)"
         vertxEventBus.login username, password, next
-        $timeout (-> deferred.reject()), timeout
+        $interval (-> deferred.reject()), timeout, 1
         return deferred.promise
 
     util.registerHandler.displayName = "#{CONSTANTS.MODULE}/#{CONSTANTS.COMPONENT}: util.registerHandler"

--- a/test/unit/angularVertxbusAdapterSpec.js
+++ b/test/unit/angularVertxbusAdapterSpec.js
@@ -550,6 +550,12 @@ describe('knalli.angular-vertxbus', function () {
 
       describe('send() should call the error callback', function () {
 
+        var $interval;
+
+        beforeEach(inject(function (_$interval_) {
+          $interval = _$interval_; // angular.mock.$interval
+        }));
+
         it('via promise.then()', function (done) {
           var successCalled, errorCalled;
           setTimeout(function () {
@@ -560,7 +566,7 @@ describe('knalli.angular-vertxbus', function () {
               errorCalled = true;
             });
             setTimeout(function () {
-              $timeout.flush();
+              $interval.flush(20); // goto T+20
               expect(successCalled).to.be(undefined);
               expect(errorCalled).to.be(true);
               done();
@@ -578,7 +584,7 @@ describe('knalli.angular-vertxbus', function () {
               errorCalled = true;
             });
             setTimeout(function () {
-              $timeout.flush();
+              $interval.flush(20); // goto T+20
               expect(successCalled).to.be(undefined);
               expect(errorCalled).to.be(true);
               done();


### PR DESCRIPTION
...otractor tests can continue

When using protractor for e2e testing it waits for all pending timeouts to complete and only then will it move on to the next test. For this reason it is important to cancel any timeouts which have been set when they are no longer needed. Currently my tests wait for 10 seconds even though they have received the correct response from the event bus.

This change replaces the $timeout service with the $interval service as the $interval service does not prevent protractor from continuing (https://github.com/angular/angular.js/issues/2402)