### PR TITLE
feat(reconnect-now): add reconnectNow to allow reconnecting immediately

### DIFF
--- a/src/wrapper.coffee
+++ b/src/wrapper.coffee
@@ -115,6 +115,8 @@ angular.module('knalli.angular-vertxbus')
       # Because we have rebuild an EventBus object (because it have to rebuild a SockJS object)
       # we must wrap the object. Therefore, we have to mimic the behavior of onopen and onclose each time.
       eventBus = null
+      reconnectNowRequested = false
+
       connect = ->
         eventBus = new EventBusOriginal url, undefined, sockjsOptions
         eventBus.onopen = ->
@@ -122,9 +124,14 @@ angular.module('knalli.angular-vertxbus')
           EventBusStub.onopen() if typeof EventBusStub.onopen is 'function'
           return #void
         eventBus.onclose = ->
-          $log.debug("[Vert.x EB Stub] Reconnect in #{sockjsReconnectInterval}ms") if debugEnabled
           EventBusStub.onclose() if typeof EventBusStub.onclose is 'function'
-          $timeout(connect, sockjsReconnectInterval) if reconnectEnabled
+          if reconnectNowRequested
+            $log.debug("[Vert.x EB Stub] Reconnect immediately") if debugEnabled
+            reconnectNowRequested = false
+            connect()
+          else
+            $log.debug("[Vert.x EB Stub] Reconnect in #{sockjsReconnectInterval}ms") if debugEnabled
+            $timeout(connect, sockjsReconnectInterval) if reconnectEnabled
           return #void
         return #void
       connect()
@@ -132,6 +139,12 @@ angular.module('knalli.angular-vertxbus')
       EventBusStub =
         reconnect: ->
           eventBus.close()
+        reconnectNow: ->
+          if eventBus.readyState() == EventBusOriginal.OPEN
+            reconnectNowRequested = true
+            eventBus.close()
+          else
+            connect()
         close: ->
           eventBus.close()
         login: (username, password, replyHandler) ->

--- a/test/unit/angularVertxbusAdapterSpec.js
+++ b/test/unit/angularVertxbusAdapterSpec.js
@@ -5,6 +5,10 @@ describe('knalli.angular-vertxbus', function () {
 
   beforeEach(module('knalli.angular-vertxbus'));
 
+  beforeEach(module('knalli.angular-vertxbus', function($provide) {
+    $provide.value('$log', window.console);
+  }));
+
   it('should have vertxEventBus', function () {
     inject(function (vertxEventBus) {
       expect(vertxEventBus).not.to.be(undefined);
@@ -109,6 +113,61 @@ describe('knalli.angular-vertxbus', function () {
             $timeout.flush();
           }, 100);
         }, 100);
+      });
+    });
+
+    describe('reconnectNow()', function () {
+      it('should be a function', function () {
+        expect(typeof vertxEventBus.reconnectNow).to.be('function');
+      });
+      it('should call the onopen function if not previously connected', function (done) {
+          this.timeout(20000);
+          var onopenCount = 0;
+          vertxEventBus.onopen = function () {
+            $log.debug('onopen');
+            onopenCount++;
+          };
+          var oncloseCount = 0;
+          vertxEventBus.onclose = function () {
+            $log.debug('onclose');
+            oncloseCount++;
+          };
+          setTimeout(function () {
+            expect(onopenCount).to.be(1);
+            $log.debug('reconnecting..');
+            vertxEventBus.close();
+            vertxEventBus.reconnectNow();
+            setTimeout(function () {
+              $log.debug('check..');
+              expect(oncloseCount).to.be(1);
+              expect(onopenCount).to.be(2);
+              done();
+            }, 1200);
+          }, 200);
+      });
+      it('should call the onclose and onopen function if previously connected', function (done) {
+        this.timeout(20000);
+        var onopenCount = 0;
+        vertxEventBus.onopen = function () {
+          $log.debug('onopen');
+          onopenCount++;
+        };
+        var oncloseCount = 0;
+        vertxEventBus.onclose = function () {
+          $log.debug('onclose');
+          oncloseCount++;
+        };
+        setTimeout(function () {
+          expect(onopenCount, 'onopenCount').to.be(1);
+          $log.debug('reconnecting..');
+          vertxEventBus.reconnectNow();
+          setTimeout(function () {
+            $log.debug('check..');
+            expect(oncloseCount, 'oncloseCount').to.be(1);
+            expect(onopenCount, 'onopenCount').to.be(2);
+            done();
+          }, 1200);
+        }, 200);
       });
     });
 


### PR DESCRIPTION
(This replaced my previous pull requests)

The current reconnect method is just closing the socket and waiting for the reconnect timeout to happen.
I've added a new reconnectNow method that reconnects 'immediately'.
It also can be used to connect if the connection is currently closed.

Both could also happen within the reconnect method instead but I wasn't sure whether the existing behaviour was intentional.